### PR TITLE
Implement permission CRUD API

### DIFF
--- a/backend/src/main/java/com/mymatch/controller/PermissionController.java
+++ b/backend/src/main/java/com/mymatch/controller/PermissionController.java
@@ -1,14 +1,69 @@
 package com.mymatch.controller;
 
+import com.mymatch.dto.request.role.PermissionRequest;
+import com.mymatch.dto.response.ApiResponse;
+import com.mymatch.dto.response.role.PermissionResponse;
+import com.mymatch.service.PermissionService;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/permissions")
 @RequiredArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class PermissionController {
+
+    PermissionService permissionService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<PermissionResponse> createPermission(@RequestBody PermissionRequest req) {
+        return ApiResponse.<PermissionResponse>builder()
+                .code(HttpStatus.CREATED.value())
+                .message("Tạo quyền thành công")
+                .result(permissionService.createPermission(req))
+                .build();
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<PermissionResponse> getById(@PathVariable Long id) {
+        return ApiResponse.<PermissionResponse>builder()
+                .code(HttpStatus.OK.value())
+                .message("Lấy thông tin quyền thành công")
+                .result(permissionService.getById(id))
+                .build();
+    }
+
+    @PutMapping("/{id}")
+    public ApiResponse<PermissionResponse> updatePermission(@PathVariable Long id, @RequestBody PermissionRequest req) {
+        return ApiResponse.<PermissionResponse>builder()
+                .code(HttpStatus.OK.value())
+                .message("Cập nhật quyền thành công")
+                .result(permissionService.updatePermission(id, req))
+                .build();
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public ApiResponse<PermissionResponse> deletePermission(@PathVariable Long id) {
+        return ApiResponse.<PermissionResponse>builder()
+                .code(HttpStatus.NO_CONTENT.value())
+                .message("Xoá quyền thành công")
+                .result(permissionService.deletePermission(id))
+                .build();
+    }
+
+    @GetMapping
+    public ApiResponse<List<PermissionResponse>> getAllPermissions() {
+        return ApiResponse.<List<PermissionResponse>>builder()
+                .code(HttpStatus.OK.value())
+                .message("Lấy danh sách quyền thành công")
+                .result(permissionService.getAllPermissions())
+                .build();
+    }
 }

--- a/backend/src/main/java/com/mymatch/exception/ErrorCode.java
+++ b/backend/src/main/java/com/mymatch/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     COURSE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "Môn học không tồn tại", HttpStatus.NOT_FOUND),
     USER_NOT_EXISTED(HttpStatus.NOT_FOUND.value(), "Người dùng không tồn tại", HttpStatus.NOT_FOUND),
     ROLE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "Không tìm thấy vai trò", HttpStatus.NOT_FOUND),
+    PERMISSION_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "Không tìm thấy quyền", HttpStatus.NOT_FOUND),
     UNIVERSITY_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "Không tìm thấy trường đại học", HttpStatus.NOT_FOUND),
     LECTURER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "Không tìm thấy giảng viên", HttpStatus.NOT_FOUND),
     CAMPUS_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "Không tìm thấy cơ sở", HttpStatus.NOT_FOUND),
@@ -45,7 +46,8 @@ public enum ErrorCode {
     CAMPUS_EXISTED(HttpStatus.CONFLICT.value(), "Cơ sở đã tồn tại", HttpStatus.CONFLICT),
     COURSE_EXISTED(HttpStatus.CONFLICT.value(), "Mã môn học đã tồn tại", HttpStatus.CONFLICT),
     STUDENT_CODE_EXISTED(HttpStatus.CONFLICT.value(), "Mã sinh viên đã tồn tại", HttpStatus.CONFLICT),
-    ROLE_EXISTED(HttpStatus.CONFLICT.value(), "Vai trò đã tồn tại", HttpStatus.CONFLICT),;
+    ROLE_EXISTED(HttpStatus.CONFLICT.value(), "Vai trò đã tồn tại", HttpStatus.CONFLICT),
+    PERMISSION_EXISTED(HttpStatus.CONFLICT.value(), "Quyền đã tồn tại", HttpStatus.CONFLICT);
 
 
     ErrorCode(int code, String message, HttpStatusCode statusCode) {

--- a/backend/src/main/java/com/mymatch/mapper/PermissionMapper.java
+++ b/backend/src/main/java/com/mymatch/mapper/PermissionMapper.java
@@ -1,10 +1,22 @@
 package com.mymatch.mapper;
 
+import com.mymatch.dto.request.role.PermissionRequest;
+import com.mymatch.dto.response.role.PermissionResponse;
+import com.mymatch.entity.Permission;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import org.mapstruct.NullValuePropertyMappingStrategy;
 
 @Mapper(
         componentModel = "spring",
         nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
 public interface PermissionMapper {
+    @Mapping(target = "id", ignore = true)
+    Permission toPermission(PermissionRequest request);
+
+    PermissionResponse toPermissionResponse(Permission permission);
+
+    @Mapping(target = "id", ignore = true)
+    void updatePermission(@MappingTarget Permission permission, PermissionRequest request);
 }

--- a/backend/src/main/java/com/mymatch/repository/PermissionRepository.java
+++ b/backend/src/main/java/com/mymatch/repository/PermissionRepository.java
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Repository;
 import com.mymatch.entity.Permission;
 
 @Repository
-public interface PermissionRepository extends JpaRepository<Permission, Long> {}
+public interface PermissionRepository extends JpaRepository<Permission, Long> {
+    boolean existsByName(String name);
+}

--- a/backend/src/main/java/com/mymatch/service/PermissionService.java
+++ b/backend/src/main/java/com/mymatch/service/PermissionService.java
@@ -1,3 +1,25 @@
 package com.mymatch.service;
 
-public interface PermissionService {}
+import com.mymatch.dto.request.role.PermissionRequest;
+import com.mymatch.dto.response.role.PermissionResponse;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import java.util.List;
+
+public interface PermissionService {
+
+    @PreAuthorize("hasRole('MANAGER')")
+    PermissionResponse createPermission(PermissionRequest request);
+
+    @PreAuthorize("hasRole('MANAGER')")
+    PermissionResponse updatePermission(Long id, PermissionRequest request);
+
+    @PreAuthorize("hasRole('MANAGER')")
+    PermissionResponse deletePermission(Long id);
+
+    @PreAuthorize("hasRole('MANAGER')")
+    PermissionResponse getById(Long id);
+
+    @PreAuthorize("hasRole('MANAGER')")
+    List<PermissionResponse> getAllPermissions();
+}

--- a/backend/src/main/java/com/mymatch/service/impl/PermissionServiceImpl.java
+++ b/backend/src/main/java/com/mymatch/service/impl/PermissionServiceImpl.java
@@ -1,14 +1,73 @@
 package com.mymatch.service.impl;
 
+import com.mymatch.dto.request.role.PermissionRequest;
+import com.mymatch.dto.response.role.PermissionResponse;
+import com.mymatch.entity.Permission;
+import com.mymatch.exception.AppException;
+import com.mymatch.exception.ErrorCode;
+import com.mymatch.mapper.PermissionMapper;
+import com.mymatch.repository.PermissionRepository;
+import com.mymatch.service.PermissionService;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
-public class PermissionServiceImpl {
+public class PermissionServiceImpl implements PermissionService {
+
+    PermissionRepository permissionRepository;
+    PermissionMapper permissionMapper;
+
+    @Override
+    public PermissionResponse createPermission(PermissionRequest request) {
+        if (permissionRepository.existsByName(request.getName())) {
+            throw new AppException(ErrorCode.PERMISSION_EXISTED);
+        }
+        Permission permission = permissionMapper.toPermission(request);
+        Permission saved = permissionRepository.save(permission);
+        return permissionMapper.toPermissionResponse(saved);
+    }
+
+    @Override
+    public PermissionResponse updatePermission(Long id, PermissionRequest request) {
+        Permission existing = permissionRepository.findById(id)
+                .orElseThrow(() -> new AppException(ErrorCode.PERMISSION_NOT_FOUND));
+        if (request.getName() != null && permissionRepository.existsByName(request.getName())
+                && !existing.getName().equals(request.getName())) {
+            throw new AppException(ErrorCode.PERMISSION_EXISTED);
+        }
+        permissionMapper.updatePermission(existing, request);
+        Permission updated = permissionRepository.save(existing);
+        return permissionMapper.toPermissionResponse(updated);
+    }
+
+    @Override
+    public PermissionResponse deletePermission(Long id) {
+        Permission permission = permissionRepository.findById(id)
+                .orElseThrow(() -> new AppException(ErrorCode.PERMISSION_NOT_FOUND));
+        PermissionResponse response = permissionMapper.toPermissionResponse(permission);
+        permissionRepository.delete(permission);
+        return response;
+    }
+
+    @Override
+    public PermissionResponse getById(Long id) {
+        Permission permission = permissionRepository.findById(id)
+                .orElseThrow(() -> new AppException(ErrorCode.PERMISSION_NOT_FOUND));
+        return permissionMapper.toPermissionResponse(permission);
+    }
+
+    @Override
+    public List<PermissionResponse> getAllPermissions() {
+        return permissionRepository.findAll().stream()
+                .map(permissionMapper::toPermissionResponse)
+                .toList();
+    }
 }


### PR DESCRIPTION
## Summary
- add error codes and repository helper for permissions
- implement service, controller, and mapper for permission CRUD
- restrict permission API access to manager role

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a9629cbf6483209532536ccb2f4f03