### PR TITLE
[MM-70] Change avatarUrl column to TEXT in User entity

### DIFF
--- a/backend/src/main/java/com/mymatch/entity/User.java
+++ b/backend/src/main/java/com/mymatch/entity/User.java
@@ -48,7 +48,7 @@ public class User extends AbstractAuditingEntity {
     String lastName;
     String address;
     String phone;
-    @Column(name = "avatar_url", length = 2048)
+    @Column(name = "avatar_url", columnDefinition = "TEXT")
     String avatarUrl;
 
     @OneToOne(cascade = CascadeType.ALL)


### PR DESCRIPTION
Updated the avatarUrl field in the User entity to use columnDefinition = "TEXT" instead of specifying a length, allowing for longer URLs or image data storage.