### PR TITLE
[MM-73] Remove PreAuthorize annotation from service interface

### DIFF
--- a/backend/src/main/java/com/mymatch/service/LecturerCourseService.java
+++ b/backend/src/main/java/com/mymatch/service/LecturerCourseService.java
@@ -7,7 +7,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import java.util.List;
 
 public interface LecturerCourseService {
-    @PreAuthorize("hasAuthority('lecturercourse:create')")
     LecturerCourseResponse assign(LecturerCourseCreationRequest req);
     List<LecturerCourseResponse> getByLecturerId(Long lecturerId);
 }


### PR DESCRIPTION
The @PreAuthorize annotation was removed from the assign method in LecturerCourseService.