### PR TITLE
[MM-90] Change ChatMessageResponse timestamp fields from LocalDateTime to Instant

### DIFF
--- a/backend/src/main/java/com/mymatch/dto/response/chatmessage/ChatMessageResponse.java
+++ b/backend/src/main/java/com/mymatch/dto/response/chatmessage/ChatMessageResponse.java
@@ -1,9 +1,11 @@
 package com.mymatch.dto.response.chatmessage;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.mymatch.dto.response.conversation.ConversationResponse;
 import com.mymatch.dto.response.student.StudentResponse;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 
 @Data
@@ -17,6 +19,9 @@ public class ChatMessageResponse {
     boolean me;
     String message;
     StudentResponse sender;
-    LocalDateTime createAt;
-    LocalDateTime updateAt;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX", timezone = "UTC")
+    Instant createAt;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX", timezone = "UTC")
+    Instant updateAt;
 }

--- a/backend/src/main/java/com/mymatch/mapper/ChatMessageMapper.java
+++ b/backend/src/main/java/com/mymatch/mapper/ChatMessageMapper.java
@@ -10,12 +10,15 @@ import org.mapstruct.NullValuePropertyMappingStrategy;
 @Mapper(
         componentModel = "spring",
         uses = {ConversationMapper.class},
+        imports = { java.time.ZoneOffset.class },
         nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
 public interface ChatMessageMapper {
     ChatMessage toChatMessage(ChatMessageCreationRequest request);
     @Mapping(target = "sender.user.role", ignore = true)
     @Mapping(target = "sender.user.student", ignore = true)
     @Mapping(target = "sender.campus", ignore = true)
+    @Mapping(target = "createAt", expression = "java(chatMessage.getCreateAt().atOffset(ZoneOffset.UTC).toInstant())")
+    @Mapping(target = "updateAt", expression = "java(chatMessage.getUpdateAt().atOffset(ZoneOffset.UTC).toInstant())")
     ChatMessageResponse toChatMessageResponse(ChatMessage chatMessage);
 }
 

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -3,6 +3,8 @@ server:
 spring:
   application:
     name: MyMatch
+  jackson:
+    time-zone: UTC
   datasource:
     url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME}
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -12,6 +14,8 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+    properties:
+      hibernate.jdbc.time_zone: UTC
   security:
     user:
       name: admin


### PR DESCRIPTION
Configured Jackson and Hibernate to use UTC as the default time zone in application.yaml for consistent date and time handling across the application.