### PR TITLE
[MM-97] Adds expiry mechanism for requests

### DIFF
--- a/backend/src/main/java/com/mymatch/dto/request/studentrequest/StudentRequestCreationRequest.java
+++ b/backend/src/main/java/com/mymatch/dto/request/studentrequest/StudentRequestCreationRequest.java
@@ -3,6 +3,7 @@ import jakarta.validation.constraints.*;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -28,4 +29,6 @@ public class StudentRequestCreationRequest {
     Long campusId;
 
     Set<Long> skillIds;
+
+    LocalDateTime expiresAt = LocalDateTime.now().plusDays(14); // optional, sẽ set default 14 ngày trong service nếu null
 }

--- a/backend/src/main/java/com/mymatch/dto/request/studentrequest/StudentRequestUpdateRequest.java
+++ b/backend/src/main/java/com/mymatch/dto/request/studentrequest/StudentRequestUpdateRequest.java
@@ -3,6 +3,8 @@ import com.mymatch.enums.RequestStatus;
 import jakarta.validation.constraints.*;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -22,5 +24,5 @@ public class StudentRequestUpdateRequest {
     @NotNull Long campusId;
     Set<Long> skillIds;
     RequestStatus status;
-
+    LocalDateTime expiresAt;
 }

--- a/backend/src/main/java/com/mymatch/dto/request/swaprequest/SwapRequestUpdateRequest.java
+++ b/backend/src/main/java/com/mymatch/dto/request/swaprequest/SwapRequestUpdateRequest.java
@@ -8,7 +8,6 @@ import lombok.experimental.FieldDefaults;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Set;
 
 @Data
@@ -31,6 +30,7 @@ public class SwapRequestUpdateRequest {
     String reason;
     Visibility visibility;
     SwapRequestStatus status;
+    LocalDateTime expiresAt;
 
     Set<DayOfWeek> fromDays;
     Set<DayOfWeek> toDays;

--- a/backend/src/main/java/com/mymatch/dto/response/studentrequest/StudentRequestResponse.java
+++ b/backend/src/main/java/com/mymatch/dto/response/studentrequest/StudentRequestResponse.java
@@ -35,5 +35,6 @@ public class StudentRequestResponse {
     String description;
     RequestStatus status;
     LocalDateTime createAt;
+    LocalDateTime expiresAt;
     Set<StudentRequestSkillResponse> skills;
 }

--- a/backend/src/main/java/com/mymatch/dto/response/swaprequest/SwapRequestResponse.java
+++ b/backend/src/main/java/com/mymatch/dto/response/swaprequest/SwapRequestResponse.java
@@ -4,13 +4,11 @@ import com.mymatch.dto.response.course.CourseResponse;
 import com.mymatch.dto.response.lecturer.LecturerResponse;
 import com.mymatch.dto.response.student.StudentResponse;
 import com.mymatch.enums.*;
-import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Set;
 
 @Data
@@ -34,4 +32,6 @@ public class SwapRequestResponse {
     Set<DayOfWeek> toDays;
     ClassesSlot slotFrom;
     ClassesSlot slotTo;
+    Visibility visibility;
+    LocalDateTime expiresAt;
 }

--- a/backend/src/main/java/com/mymatch/entity/StudentRequest.java
+++ b/backend/src/main/java/com/mymatch/entity/StudentRequest.java
@@ -8,6 +8,7 @@ import lombok.experimental.FieldDefaults;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
+import java.time.LocalDateTime;
 import java.util.*;
 
 @Getter
@@ -38,6 +39,9 @@ public class StudentRequest extends AbstractAuditingEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     RequestStatus status = RequestStatus.OPEN;
+
+    @Column(name = "expires_at")
+    LocalDateTime expiresAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "course_id", nullable = false)

--- a/backend/src/main/java/com/mymatch/enums/RequestStatus.java
+++ b/backend/src/main/java/com/mymatch/enums/RequestStatus.java
@@ -2,5 +2,6 @@ package com.mymatch.enums;
 
 public enum RequestStatus {
     OPEN,
+    EXPIRED,
     CLOSED
 }

--- a/backend/src/main/java/com/mymatch/repository/StudentRequestRepository.java
+++ b/backend/src/main/java/com/mymatch/repository/StudentRequestRepository.java
@@ -3,10 +3,27 @@ package com.mymatch.repository;
 import com.mymatch.entity.StudentRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
 
 @Repository
 public interface StudentRequestRepository extends
         JpaRepository<StudentRequest, Long>,
         JpaSpecificationExecutor<StudentRequest> {
+
+    // Bulk UPDATE để đánh dấu EXPIRED cho các request đã hết hạn
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE StudentRequest sr
+           SET sr.status = com.mymatch.enums.RequestStatus.EXPIRED
+         WHERE sr.deleted = 0
+           AND sr.status = com.mymatch.enums.RequestStatus.OPEN
+           AND sr.expiresAt IS NOT NULL
+           AND sr.expiresAt < :now
+    """)
+    int expireOpenRequests(@Param("now") LocalDateTime now);
 }

--- a/backend/src/main/java/com/mymatch/repository/SwapRequestRepository.java
+++ b/backend/src/main/java/com/mymatch/repository/SwapRequestRepository.java
@@ -7,9 +7,11 @@ import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface SwapRequestRepository extends JpaRepository<SwapRequest, Long>, JpaSpecificationExecutor<SwapRequest> {
@@ -64,4 +66,15 @@ Optional<SwapRequest> findMatchingPartnerRequests(
             @Param("slotTo") ClassesSlot slotTo,
             @Param("studentId") Long studentId
     );
+
+    // Đổi trạng thái các request đã quá hạn: chỉ đổi từ SENT → EXPIRED
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE SwapRequest sr
+           SET sr.status = com.mymatch.enums.SwapRequestStatus.EXPIRED
+         WHERE sr.deleted = 0
+           AND sr.status = com.mymatch.enums.SwapRequestStatus.SENT
+           AND sr.expiresAt < :now
+    """)
+    int expireSentRequests(@Param("now") LocalDateTime now);
 }

--- a/backend/src/main/java/com/mymatch/scheduler/StudentRequestExpiryScheduler.java
+++ b/backend/src/main/java/com/mymatch/scheduler/StudentRequestExpiryScheduler.java
@@ -1,0 +1,30 @@
+package com.mymatch.scheduler;
+
+import com.mymatch.repository.StudentRequestRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StudentRequestExpiryScheduler {
+
+    private final StudentRequestRepository studentRequestRepository;
+
+    // Chạy vào lúc 23:58 hằng ngày
+    @Scheduled(cron = "0 58 23 * * *")
+    @Transactional
+    public void expireStudentRequests() {
+        var now = LocalDateTime.now();
+        int n = studentRequestRepository.expireOpenRequests(now);
+        if (n > 0) {
+            log.info("[student-request-expiry] {} requests -> EXPIRED @{}", n, now);
+        }
+    }
+}
+

--- a/backend/src/main/java/com/mymatch/scheduler/SwapRequestExpiryScheduler.java
+++ b/backend/src/main/java/com/mymatch/scheduler/SwapRequestExpiryScheduler.java
@@ -1,0 +1,30 @@
+package com.mymatch.scheduler;
+
+import com.mymatch.repository.SwapRequestRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SwapRequestExpiryScheduler {
+
+    private final SwapRequestRepository swapRequestRepository;
+
+    // Chạy vào lúc 23:57 hằng ngày
+    @Scheduled(cron = "0 57 23 * * *")
+    @Transactional
+    public void expireSwapRequests() {
+        var now = LocalDateTime.now();
+        int expired = swapRequestRepository.expireSentRequests(now);
+        if (expired > 0) {
+            log.info("[swap-expiry] {} requests -> EXPIRED @{}", expired, now);
+        }
+    }
+}
+


### PR DESCRIPTION
Implements a mechanism to automatically expire student and swap requests.

This change introduces:
- 'expiresAt' field in StudentRequest and SwapRequest entities and DTOs
- A scheduled task to periodically update the status of expired requests to EXPIRED.
- A default expiry time of 14 days for StudentRequest creation.
