### PR TITLE
[MM-101] Update logic student request and team deletion logic

### DIFF
--- a/backend/src/main/java/com/mymatch/service/impl/StudentRequestServiceImpl.java
+++ b/backend/src/main/java/com/mymatch/service/impl/StudentRequestServiceImpl.java
@@ -171,13 +171,22 @@ public class StudentRequestServiceImpl implements StudentRequestService {
         User currentUser = userRepository
                 .findById(SecurityUtil.getCurrentUserId())
                 .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_FOUND));
-        if (currentUser.getStudent() == null) throw new AppException(ErrorCode.STUDENT_INFO_REQUIRED);
 
         StudentRequest sr =
                 studentRequestRepository.findById(id).orElseThrow(() -> new AppException(ErrorCode.ENTITY_NOT_FOUND));
 
-        if (!sr.getStudent().getId().equals(currentUser.getStudent().getId())
-                && !SecurityUtil.hasAuthority("student_request:delete")) {
+        // Nếu có quyền admin/moderator thì cho phép xóa luôn
+        if (SecurityUtil.hasAuthority("student_request:delete")) {
+            studentRequestRepository.delete(sr);
+            return;
+        }
+
+        // Nếu không có quyền đặc biệt, phải là chủ sở hữu
+        if (currentUser.getStudent() == null) {
+            throw new AppException(ErrorCode.STUDENT_INFO_REQUIRED);
+        }
+
+        if (!sr.getStudent().getId().equals(currentUser.getStudent().getId())) {
             throw new AppException(ErrorCode.ACCESS_DENIED);
         }
 

--- a/backend/src/main/java/com/mymatch/service/impl/TeamServiceImpl.java
+++ b/backend/src/main/java/com/mymatch/service/impl/TeamServiceImpl.java
@@ -202,9 +202,11 @@ public class TeamServiceImpl implements TeamService {
     }
 
     @Override
+    @Transactional
     public void deleteTeam(Long id) {
         Team team = teamRepository.findById(id).orElseThrow(() -> new AppException(ErrorCode.TEAM_NOT_FOUND));
         checkOwnerOrAdmin(team, "team:delete");
+        team.getRequests().forEach(tr -> tr.setStatus(com.mymatch.enums.RequestStatus.CLOSED));
         teamRepository.delete(team);
     }
 


### PR DESCRIPTION
Enhances student request deletion to allow admins/moderators
to bypass ownership checks.

Updates team deletion to close associated requests
when a team is deleted.
